### PR TITLE
fix: ghostty-pane-splitter 記事の改善

### DIFF
--- a/.textlintrc.json
+++ b/.textlintrc.json
@@ -1,4 +1,9 @@
 {
+    "filters": {
+        "allowlist": {
+            "allow": [":::"]
+        }
+    },
     "rules": {
         "preset-ja-technical-writing": {
             "no-exclamation-question-mark": false

--- a/articles/ghostty_pane_splitter.md
+++ b/articles/ghostty_pane_splitter.md
@@ -135,13 +135,15 @@ ghostty-pane-splitter 2,1,3
 
 ghostty-pane-splitter は [enigo](https://github.com/enigo-rs/enigo) というクレートを使ってキーボード入力をシミュレートし、Ghostty のpane分割を自動化しています。
 
+https://github.com/enigo-rs/enigo
+
 処理の流れは以下の通りです。
 
 1. Ghostty の設定ファイルを読み取り、pane分割に必要なキーバインドを取得する
 2. 指定されたレイアウトに応じて必要な分割操作の順序を計算する
 3. enigo を通じてキーボード入力をシミュレートし、Ghostty のキーバインドを順番に発火させる
 
-enigo は macOS では Core Graphics Event API、Linux では X11 (libxdo) を利用してキーストロークを送信します。このクレートが OS ごとの差異を吸収してくれるため、同一のコードベースで macOS / Linux の両方に対応できています。
+enigo は macOS では [Core Graphics Event API](https://developer.apple.com/documentation/coregraphics/cgevent)、Linux では [libxdo (xdotool)](https://github.com/jordansissel/xdotool) を利用してキーストロークを送信します。このクレートが OS ごとの差異を吸収してくれるため、同一のコードベースで macOS / Linux の両方に対応できています。
 
 :::message
 Windows は Ghostty 自体が未サポートのため、ghostty-pane-splitter も Windows には対応していません。

--- a/articles/ghostty_pane_splitter.md
+++ b/articles/ghostty_pane_splitter.md
@@ -10,7 +10,7 @@ published_at: 2026-03-19 07:00
 [Ghostty](https://ghostty.org/) は軽量かつ設定が簡単で、最近は [Claude Code](https://code.claude.com/) や [Codex CLI](https://github.com/openai/codex) などの AI Coding Agent を動かすのによく使われています。
 Ghostty は pane 分割機能を備えていますが、分割のたびにショートカットキーを押す必要があります。例えば「左に Claude Code、右上にエディタ、右下に dev server」のようなレイアウトを毎回手動で組み立てるのは面倒です。
 
-この課題に対して、すでに[いくつかのアプローチ](#参考文献)が紹介されています。ただし macOS 限定のものが多かったため、macOS / Linux の両方で動作する CLI ツール「ghostty-pane-splitter」を Rust で作りました。
+この課題に対して、すでに[いくつかのアプローチ](#参考文献)が紹介されています。二番煎じではありますが、macOS / Linux の両方で動作する CLI ツール「ghostty-pane-splitter」を作りました。
 
 https://github.com/rikeda71/ghostty-pane-splitter
 

--- a/articles/ghostty_pane_splitter.md
+++ b/articles/ghostty_pane_splitter.md
@@ -85,7 +85,7 @@ Ghostty の設定ファイルは以下のパスにあります。
 
 ### レイアウト指定
 
-```
+```bash
 ghostty-pane-splitter <LAYOUT>
 ```
 

--- a/articles/ghostty_pane_splitter.md
+++ b/articles/ghostty_pane_splitter.md
@@ -9,7 +9,7 @@ published: false
 [Ghostty](https://ghostty.org/) は軽量かつ設定が簡単で、最近は [Claude Code](https://code.claude.com/) や [Codex CLI](https://github.com/openai/codex) などの AI Coding Agent を動かすのによく使われています。
 Ghostty で pane を分割する場合、決まったフォーマットに分割したい場合でも、毎回手動で分割する必要があります。
 
-この課題に対して、すでに[いくつかのアプローチ](#参考文献)が紹介されています。n番煎じではありますが、macOS / Linux の両方で動作する CLI ツール「ghostty-pane-splitter」を Rust で作ったので紹介します。
+この課題に対して、すでに[いくつかのアプローチ](#参考文献)が紹介されています。n 番煎じではありますが、macOS / Linux の両方で動作する CLI ツール「ghostty-pane-splitter」を Rust で作ったので紹介します。
 
 https://github.com/rikeda71/ghostty-pane-splitter
 
@@ -61,7 +61,7 @@ sudo mv ghostty-pane-splitter /usr/local/bin/
 - `goto_split:previous`
 - `equalize_splits`
 
-キーの組み合わせは任意で構いません。設定の詳細は [Ghostty のキーバインドリファレンス](https://ghostty.org/docs/config/keybind/reference)を参照してください。以下は設定例です。
+キーの組み合わせは任意で構いません。設定の詳細は [Ghostty のキーバインドリファレンス](https://ghostty.org/docs/config/keybind/reference) を参照してください。以下は設定例です。
 
 ```
 keybind = super+d=new_split:right
@@ -88,17 +88,17 @@ Ghostty の設定ファイルは以下のパスにあります。
 ghostty-pane-splitter <LAYOUT>
 ```
 
-`<LAYOUT>` にはpane数、グリッド指定（`列x行`）、またはカスタム列レイアウト（カンマ区切りで各列の行数を指定）を渡します。
+`<LAYOUT>` には pane 数、グリッド指定（`列x行`）、またはカスタム列レイアウト（カンマ区切りで各列の行数を指定）を渡します。
 
 #### 数値指定
 
-pane数を数値で指定すると、自動的にグリッドレイアウトを計算して分割します。
+pane 数を数値で指定すると、自動的にグリッドレイアウトを計算して分割します。
 
 ```bash
-# 4paneに分割 (2x2 グリッド)
+# 4 pane に分割 (2x2 グリッド)
 ghostty-pane-splitter 4
 
-# 9paneに分割 (3x3 グリッド)
+# 9 pane に分割 (3x3 グリッド)
 ghostty-pane-splitter 9
 ```
 
@@ -125,13 +125,13 @@ ghostty-pane-splitter 2,1,3
 
 ## 実装について
 
-ghostty-pane-splitter は [enigo](https://github.com/enigo-rs/enigo) というクレートを使ってキーボード入力をシミュレートし、Ghostty のpane分割を自動化しています。
+ghostty-pane-splitter は [enigo](https://github.com/enigo-rs/enigo) というクレートを使ってキーボード入力をシミュレートし、Ghostty の pane 分割を自動化しています。
 
 https://github.com/enigo-rs/enigo
 
 処理の流れは以下の通りです。
 
-1. Ghostty の設定ファイルを読み取り、pane分割に必要なキーバインドを取得する
+1. Ghostty の設定ファイルを読み取り、pane 分割に必要なキーバインドを取得する
 2. 指定されたレイアウトに応じて必要な分割操作の順序を計算する
 3. enigo を通じてキーボード入力をシミュレートし、Ghostty のキーバインドを順番に発火させる
 
@@ -143,7 +143,7 @@ Windows は Ghostty 自体が未サポートのため、ghostty-pane-splitter �
 
 ## 終わりに
 
-Ghostty のpane分割を CLI で自動化するツール ghostty-pane-splitter を紹介しました。よければご利用ください！
+Ghostty の pane 分割を CLI で自動化するツール ghostty-pane-splitter を紹介しました。よければご利用ください！
 
 star や PR、Issue などもお待ちしています。
 

--- a/articles/ghostty_pane_splitter.md
+++ b/articles/ghostty_pane_splitter.md
@@ -8,7 +8,7 @@ published_at: 2026-03-19 07:00
 ---
 
 [Ghostty](https://ghostty.org/) は軽量かつ設定が簡単で、最近は [Claude Code](https://code.claude.com/) や [Codex CLI](https://github.com/openai/codex) などの AI Coding Agent を動かすのによく使われています。
-例えば「左に Claude Code、右上にエディタ、右下に dev server」のようなレイアウトを毎回手動で分割するのは面倒です。
+Ghostty は pane 分割機能を備えていますが、分割のたびにショートカットキーを押す必要があります。例えば「左に Claude Code、右上にエディタ、右下に dev server」のようなレイアウトを毎回手動で組み立てるのは面倒です。
 
 この課題に対して、すでに[いくつかのアプローチ](#参考文献)が紹介されています。ただし macOS 限定のものが多かったため、macOS / Linux の両方で動作する CLI ツール「ghostty-pane-splitter」を Rust で作りました。
 

--- a/articles/ghostty_pane_splitter.md
+++ b/articles/ghostty_pane_splitter.md
@@ -1,5 +1,5 @@
 ---
-title: "Ghostty の pane 分割を CLI で自動化するツール ghostty-pane-splitter を作った"
+title: "Ghostty の pane 分割をコマンド一発で自動化する CLI ツールを作った"
 emoji: "👻"
 type: "tech"
 topics: ["ghostty", "rust", "cli", "terminal"]
@@ -8,9 +8,9 @@ published_at: 2026-03-19 07:00
 ---
 
 [Ghostty](https://ghostty.org/) は軽量かつ設定が簡単で、最近は [Claude Code](https://code.claude.com/) や [Codex CLI](https://github.com/openai/codex) などの AI Coding Agent を動かすのによく使われています。
-Ghostty で pane を分割する場合、決まったフォーマットに分割したい場合でも、毎回手動で分割する必要があります。
+例えば「左に Claude Code、右上にエディタ、右下に dev server」のようなレイアウトを毎回手動で分割するのは面倒です。
 
-この課題に対して、すでに[いくつかのアプローチ](#参考文献)が紹介されています。二番煎じではありますが、macOS / Linux の両方で動作する CLI ツール「ghostty-pane-splitter」を Rust で作ったので紹介します。
+この課題に対して、すでに[いくつかのアプローチ](#参考文献)が紹介されています。ただし macOS 限定のものが多かったため、macOS / Linux の両方で動作する CLI ツール「ghostty-pane-splitter」を Rust で作りました。
 
 https://github.com/rikeda71/ghostty-pane-splitter
 
@@ -18,11 +18,17 @@ https://github.com/rikeda71/ghostty-pane-splitter
 
 数値、グリッド、カスタムの3種類のレイアウト指定で pane 分割を自動化できます。
 
-| 指定方法 | デモ |
-| --- | --- |
-| 数値指定 (`ghostty-pane-splitter 4`) | ![number](/images/ghostty_pane_splitter/demo-number.gif) |
-| グリッド指定 (`ghostty-pane-splitter 2x3`) | ![grid](/images/ghostty_pane_splitter/demo-grid.gif) |
-| カスタム指定 (`ghostty-pane-splitter 1,3`) | ![custom](/images/ghostty_pane_splitter/demo-custom.gif) |
+**数値指定** (`ghostty-pane-splitter 4`)
+
+![number](/images/ghostty_pane_splitter/demo-number.gif)
+
+**グリッド指定** (`ghostty-pane-splitter 2x3`)
+
+![grid](/images/ghostty_pane_splitter/demo-grid.gif)
+
+**カスタム指定** (`ghostty-pane-splitter 1,3`)
+
+![custom](/images/ghostty_pane_splitter/demo-custom.gif)
 
 ## インストール
 
@@ -126,17 +132,13 @@ ghostty-pane-splitter 2,1,3
 
 ## 実装について
 
-ghostty-pane-splitter は [enigo](https://github.com/enigo-rs/enigo) というクレートを使ってキーボード入力をシミュレートし、Ghostty の pane 分割を自動化しています。
-
-https://github.com/enigo-rs/enigo
-
-処理の流れは以下の通りです。
+ghostty-pane-splitter は [enigo](https://github.com/enigo-rs/enigo) というクレートを使ってキーボード入力をシミュレートし、Ghostty の pane 分割を自動化しています。処理の流れは以下の通りです。
 
 1. Ghostty の設定ファイルを読み取り、pane 分割に必要なキーバインドを取得する
 2. 指定されたレイアウトに応じて必要な分割操作の順序を計算する
 3. enigo を通じてキーボード入力をシミュレートし、Ghostty のキーバインドを順番に発火させる
 
-enigo は macOS では [Core Graphics Event API](https://developer.apple.com/documentation/coregraphics/cgevent)、Linux では [libxdo (xdotool)](https://github.com/jordansissel/xdotool) を利用してキーストロークを送信します。このクレートが OS ごとの差異を吸収してくれるため、同一のコードベースで macOS / Linux の両方に対応できています。
+enigo は macOS では [Core Graphics Event API](https://developer.apple.com/documentation/coregraphics/cgevent)、Linux では [xdotool](https://github.com/jordansissel/xdotool) を利用してキーストロークを送信します。このクレートが OS ごとの差異を吸収してくれるため、同一のコードベースで macOS / Linux の両方に対応できています。
 
 :::message
 Windows は Ghostty 自体が未サポートのため、ghostty-pane-splitter も Windows には対応していません。
@@ -152,4 +154,4 @@ star や PR、Issue などもお待ちしています。
 
 https://zenn.dev/tackeyy/articles/deb12cbcb0f183
 
-https://zenn.dev/meijin/articles/ghostty-pane-split-script
+https://zenn.dev/meijin/articles/ghostty-1_3-apple-script

--- a/articles/ghostty_pane_splitter.md
+++ b/articles/ghostty_pane_splitter.md
@@ -3,13 +3,14 @@ title: "Ghostty の pane 分割を CLI で自動化するツール ghostty-pane-
 emoji: "👻"
 type: "tech"
 topics: ["ghostty", "rust", "cli", "terminal"]
-published: false
+published: true
+published_at: 2026-03-19 07:00
 ---
 
 [Ghostty](https://ghostty.org/) は軽量かつ設定が簡単で、最近は [Claude Code](https://code.claude.com/) や [Codex CLI](https://github.com/openai/codex) などの AI Coding Agent を動かすのによく使われています。
 Ghostty で pane を分割する場合、決まったフォーマットに分割したい場合でも、毎回手動で分割する必要があります。
 
-この課題に対して、すでに[いくつかのアプローチ](#参考文献)が紹介されています。n 番煎じではありますが、macOS / Linux の両方で動作する CLI ツール「ghostty-pane-splitter」を Rust で作ったので紹介します。
+この課題に対して、すでに[いくつかのアプローチ](#参考文献)が紹介されています。二番煎じではありますが、macOS / Linux の両方で動作する CLI ツール「ghostty-pane-splitter」を Rust で作ったので紹介します。
 
 https://github.com/rikeda71/ghostty-pane-splitter
 

--- a/articles/ghostty_pane_splitter.md
+++ b/articles/ghostty_pane_splitter.md
@@ -1,18 +1,27 @@
 ---
-title: "Ghostty のペイン分割を CLI で自動化するツール ghostty-pane-splitter を作った"
+title: "Ghostty の pane 分割を CLI で自動化するツール ghostty-pane-splitter を作った"
 emoji: "👻"
 type: "tech"
 topics: ["ghostty", "rust", "cli", "terminal"]
 published: false
 ---
 
-[Ghostty](https://ghostty.org/) はモダンなターミナルエミュレータで、ペイン分割機能を備えています。しかし、複数のペインを毎回手動でキーバインドを連打して分割するのは面倒です。特に、AI Coding Agent やエディタ、開発サーバーなど複数のペインを日常的にセットアップする場合、その煩わしさは顕著ではないでしょうか。
+[Ghostty](https://ghostty.org/) は軽量かつ設定が簡単で、最近は [Claude Code](https://code.claude.com/) や [Codex CLI](https://github.com/openai/codex) などの AI Coding Agent を動かすのによく使われています。
+Ghostty で pane を分割する場合、決まったフォーマットに分割したい場合でも、毎回手動で分割する必要があります。
 
-この課題に対して、すでに tackeyy さんの [ghostty-layout](https://github.com/tackeyy/ghostty-layout) や meijin さんの [AppleScript を使ったアプローチ](https://zenn.dev/meijin/articles/ghostty-pane-split-script)など、先行する取り組みがあります。n番煎じではありますが、macOS / Linux の両方で動作する CLI ツール「ghostty-pane-splitter」を Rust で作ったので紹介します。
+この課題に対して、すでに[いくつかのアプローチ](#参考文献)が紹介されています。n番煎じではありますが、macOS / Linux の両方で動作する CLI ツール「ghostty-pane-splitter」を Rust で作ったので紹介します。
 
 https://github.com/rikeda71/ghostty-pane-splitter
 
-![demo](/images/ghostty_pane_splitter/demo-number.gif)
+## できること
+
+数値、グリッド、カスタムの3種類のレイアウト指定で pane 分割を自動化できます。
+
+| 指定方法 | デモ |
+| --- | --- |
+| 数値指定 (`ghostty-pane-splitter 4`) | ![number](/images/ghostty_pane_splitter/demo-number.gif) |
+| グリッド指定 (`ghostty-pane-splitter 2x3`) | ![grid](/images/ghostty_pane_splitter/demo-grid.gif) |
+| カスタム指定 (`ghostty-pane-splitter 1,3`) | ![custom](/images/ghostty_pane_splitter/demo-custom.gif) |
 
 ## インストール
 
@@ -35,10 +44,6 @@ cargo install ghostty-pane-splitter
 curl -fsSL https://github.com/rikeda71/ghostty-pane-splitter/releases/latest/download/ghostty-pane-splitter-aarch64-apple-darwin.tar.gz | tar xz
 sudo mv ghostty-pane-splitter /usr/local/bin/
 
-# macOS (Intel)
-curl -fsSL https://github.com/rikeda71/ghostty-pane-splitter/releases/latest/download/ghostty-pane-splitter-x86_64-apple-darwin.tar.gz | tar xz
-sudo mv ghostty-pane-splitter /usr/local/bin/
-
 # Linux (x86_64)
 curl -fsSL https://github.com/rikeda71/ghostty-pane-splitter/releases/latest/download/ghostty-pane-splitter-x86_64-unknown-linux-gnu.tar.gz | tar xz
 sudo mv ghostty-pane-splitter /usr/local/bin/
@@ -52,56 +57,19 @@ cd ghostty-pane-splitter
 cargo install --path .
 ```
 
-## 使い方
+## 使い方と設定
 
-```
-ghostty-pane-splitter <LAYOUT>
-```
+### Ghostty の設定
 
-`<LAYOUT>` にはペイン数、グリッド指定（`列x行`）、またはカスタム列レイアウト（カンマ区切りで各列の行数を指定）を渡します。
+このツールは Ghostty の設定ファイルからキーバインドを読み取って動作します。以下の5つのアクションに対するキーバインドを Ghostty の設定ファイルに追加してください。
 
-### 数値指定
+- `new_split:right`
+- `new_split:down`
+- `goto_split:next`
+- `goto_split:previous`
+- `equalize_splits`
 
-ペイン数を数値で指定すると、自動的にグリッドレイアウトを計算して分割します。
-
-```bash
-# 4ペインに分割 (2x2 グリッド)
-ghostty-pane-splitter 4
-
-# 9ペインに分割 (3x3 グリッド)
-ghostty-pane-splitter 9
-```
-
-![number](/images/ghostty_pane_splitter/demo-number.gif)
-
-### グリッド指定（CxR 形式）
-
-列数と行数を `列x行` の形式で明示的に指定できます。
-
-```bash
-# 2列 x 3行 で分割
-ghostty-pane-splitter 2x3
-```
-
-![grid](/images/ghostty_pane_splitter/demo-grid.gif)
-
-### カスタムレイアウト指定
-
-カンマ区切りで各列の行数を指定することで、不均一なレイアウトも作成できます。
-
-```bash
-# 左 1 ペイン、右 3 ペイン
-ghostty-pane-splitter 1,3
-
-# 3列で各 2, 1, 3 行
-ghostty-pane-splitter 2,1,3
-```
-
-![custom](/images/ghostty_pane_splitter/demo-custom.gif)
-
-## Ghostty の設定
-
-このツールは Ghostty の設定ファイルからキーバインドを読み取って動作します。以下の5つのキーバインドを Ghostty の設定ファイルに追加してください。
+キーの組み合わせは任意で構いません。設定の詳細は [Ghostty のキーバインドリファレンス](https://ghostty.org/docs/config/keybind/reference)を参照してください。以下は設定例です。
 
 ```
 keybind = super+d=new_split:right
@@ -122,29 +90,54 @@ Ghostty の設定ファイルは以下のパスにあります。
 設定ファイルが見つからない場合や必要なキーバインドが不足している場合はエラーが表示されます。上記の5つのキーバインドがすべて設定されていることを確認してください。
 :::
 
-## AI Coding Agent との連携
+### レイアウト指定
 
-Ghostty は [Claude Code](https://code.claude.com/) や [Codex CLI](https://github.com/openai/codex) などの CLI ベースの AI Coding Agent に最適なターミナルとして注目されています。`ghostty-pane-splitter` を使えば、AI エージェント・エディタ・開発サーバーなどのマルチペインレイアウトをコマンド一発で構築できます。
-
-```bash
-# 3 ペインレイアウト: 左: AI エージェント、右上: エディタ、右下: ターミナル
-ghostty-pane-splitter 1,2
+```
+ghostty-pane-splitter <LAYOUT>
 ```
 
-また、[git worktree](https://git-scm.com/docs/git-worktree) と組み合わせて複数の AI エージェントを並列実行するワークフローが注目されています。`ghostty-pane-splitter` なら tmux 不要でマルチエージェントレイアウトを瞬時にセットアップできます。
+`<LAYOUT>` にはpane数、グリッド指定（`列x行`）、またはカスタム列レイアウト（カンマ区切りで各列の行数を指定）を渡します。
+
+#### 数値指定
+
+pane数を数値で指定すると、自動的にグリッドレイアウトを計算して分割します。
 
 ```bash
-# 4 ペインレイアウトで複数の AI エージェントを git worktree と並列実行
+# 4paneに分割 (2x2 グリッド)
 ghostty-pane-splitter 4
+
+# 9paneに分割 (3x3 グリッド)
+ghostty-pane-splitter 9
+```
+
+#### グリッド指定（CxR 形式）
+
+列数と行数を `列x行` の形式で明示的に指定できます。
+
+```bash
+# 2列 x 3行 で分割
+ghostty-pane-splitter 2x3
+```
+
+#### カスタムレイアウト指定
+
+カンマ区切りで各列の行数を指定することで、不均一なレイアウトも作成できます。
+
+```bash
+# 左 1 pane、右 3 pane
+ghostty-pane-splitter 1,3
+
+# 3列で各 2, 1, 3 行
+ghostty-pane-splitter 2,1,3
 ```
 
 ## 実装について
 
-ghostty-pane-splitter は [enigo](https://github.com/enigo-rs/enigo) というクレートを使ってキーボード入力のシミュレーションを行い、Ghostty のペイン分割を自動化しています。
+ghostty-pane-splitter は [enigo](https://github.com/enigo-rs/enigo) というクレートを使ってキーボード入力をシミュレートし、Ghostty のpane分割を自動化しています。
 
 処理の流れは以下の通りです。
 
-1. Ghostty の設定ファイルを読み取り、ペイン分割に必要なキーバインドを取得する
+1. Ghostty の設定ファイルを読み取り、pane分割に必要なキーバインドを取得する
 2. 指定されたレイアウトに応じて必要な分割操作の順序を計算する
 3. enigo を通じてキーボード入力をシミュレートし、Ghostty のキーバインドを順番に発火させる
 
@@ -156,10 +149,12 @@ Windows は Ghostty 自体が未サポートのため、ghostty-pane-splitter �
 
 ## 終わりに
 
-Ghostty のペイン分割を CLI で自動化するツール ghostty-pane-splitter を紹介しました。
-
-AI Coding Agent を複数ペインで並列実行するワークフローなどで活用いただけるかと思います。よければご利用ください！
+Ghostty のpane分割を CLI で自動化するツール ghostty-pane-splitter を紹介しました。よければご利用ください！
 
 star や PR、Issue などもお待ちしています。
 
-https://github.com/rikeda71/ghostty-pane-splitter
+## 参考文献
+
+https://zenn.dev/tackeyy/articles/deb12cbcb0f183
+
+https://zenn.dev/meijin/articles/ghostty-pane-split-script

--- a/articles/ghostty_pane_splitter.md
+++ b/articles/ghostty_pane_splitter.md
@@ -49,14 +49,6 @@ curl -fsSL https://github.com/rikeda71/ghostty-pane-splitter/releases/latest/dow
 sudo mv ghostty-pane-splitter /usr/local/bin/
 ```
 
-### ソースからビルド
-
-```bash
-git clone https://github.com/rikeda71/ghostty-pane-splitter.git
-cd ghostty-pane-splitter
-cargo install --path .
-```
-
 ## 使い方と設定
 
 ### Ghostty の設定

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,9 @@
         "textlint": "^15.5.0",
         "textlint-rule-preset-ja-technical-writing": "^12.0.2",
         "zenn-cli": "^0.2.11"
+      },
+      "devDependencies": {
+        "textlint-filter-rule-allowlist": "^4.0.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -380,6 +383,13 @@
         "strip-ansi": "^6.0.1",
         "text-table": "^0.2.0"
       }
+    },
+    "node_modules/@textlint/get-config-base-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@textlint/get-config-base-dir/-/get-config-base-dir-2.0.0.tgz",
+      "integrity": "sha512-J3cG1pl2llYD4ZaZMe0qVgVaHT8RvT+/SW1FHQ8HRceNalMM9O0Y8iIgtl4GGOx4vMghoIPKFVLASw8P8bJ3ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@textlint/kernel": {
       "version": "15.5.0",
@@ -1506,6 +1516,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -2764,6 +2775,7 @@
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
       "integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@keyv/serialize": "^1.1.1"
       }
@@ -4511,6 +4523,7 @@
       "resolved": "https://registry.npmjs.org/textlint/-/textlint-15.5.0.tgz",
       "integrity": "sha512-CpdpwEKSewYMpKeoSFbMqTxKsyqjbJqPg+O3EUj0IsK3Lt+YD17mT3Rm7ryuHSbFB7Qw2EIdCx8Sjh+zfx7Heg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.24.2",
         "@textlint/ast-node-types": "15.5.0",
@@ -4543,6 +4556,29 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/textlint-filter-rule-allowlist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/textlint-filter-rule-allowlist/-/textlint-filter-rule-allowlist-4.0.0.tgz",
+      "integrity": "sha512-rOlWr12sff9ZS8mOtRACPB3l1yK0oW21Owz8XsTAgFWmRhOnBbCKw8tKMDm6EtQHO92SOfyJmT4nowxiJ85Qiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@textlint/ast-node-types": "^12.0.0",
+        "@textlint/get-config-base-dir": "^2.0.0",
+        "@textlint/regexp-string-matcher": "^1.1.0",
+        "js-yaml": "^4.1.0"
+      },
+      "peerDependencies": {
+        "textlint": ">= 9.0.0"
+      }
+    },
+    "node_modules/textlint-filter-rule-allowlist/node_modules/@textlint/ast-node-types": {
+      "version": "12.6.1",
+      "resolved": "https://registry.npmjs.org/@textlint/ast-node-types/-/ast-node-types-12.6.1.tgz",
+      "integrity": "sha512-uzlJ+ZsCAyJm+lBi7j0UeBbj+Oy6w/VWoGJ3iHRHE5eZ8Z4iK66mq+PG/spupmbllLtz77OJbY89BYqgFyjXmA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/textlint-rule-helper": {
       "version": "2.5.0",
@@ -5715,6 +5751,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -7,5 +7,8 @@
     "textlint": "^15.5.0",
     "textlint-rule-preset-ja-technical-writing": "^12.0.2",
     "zenn-cli": "^0.2.11"
+  },
+  "devDependencies": {
+    "textlint-filter-rule-allowlist": "^4.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- textlint エラーの修正（助詞重複、冗長表現、弱い表現）
- セクション構成の見直し（できること → インストール → 使い方と設定）
- GIF デモを表形式で整理
- キーバインド設定の説明を改善（アクションは必須、キーの組み合わせは任意である旨を追記）
- 参考文献セクションを追加

## Test plan
- [ ] `npx textlint articles/ghostty_pane_splitter.md` で Zenn 記法以外のエラーがないことを確認
- [ ] Zenn プレビューで表形式の GIF デモが正しく表示されることを確認
- [ ] 参考文献へのアンカーリンクが正しく動作することを確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Restructured and expanded the Ghostty pane splitter article: clarified intro, reframed references, and added a brief closing with references.
  * Added a "できること" section describing three layout modes (numeric, grid, custom) with examples and demo images.
  * Broadened installation options (Homebrew, Cargo, curl) and clarified macOS/Linux config paths and restart notes.
  * Added usage/configuration guidance including keybind setup and system integration caveats; reinforced Windows unsupported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->